### PR TITLE
Full-fidelity `venv` Pex tool.

### DIFF
--- a/crates/pexrs/src/lib.rs
+++ b/crates/pexrs/src/lib.rs
@@ -19,7 +19,7 @@ use logging_timer::time;
 use pex::{InheritPath, Pex, PexPath};
 use python_proxy::ProxySource;
 use regex::bytes::Regex;
-use venv::{Linker, Virtualenv, populate, populate_user_code_and_wheels};
+use venv::{InstallScope, Linker, Virtualenv, populate, populate_user_code_and_wheels};
 
 struct PythonProxyLinker<'a>(&'a Pex<'a>);
 
@@ -201,6 +201,7 @@ fn prepare_venv<'a>(
             &mut resolve.scripts,
             None,
             true,
+            InstallScope::All,
         )?;
         for (additional_pex, resolved_wheels) in resolve.additional_wheels {
             populate_user_code_and_wheels(
@@ -211,6 +212,7 @@ fn prepare_venv<'a>(
                 resolved_wheels,
                 false,
                 true,
+                InstallScope::All,
             )?;
         }
         Ok(venv.interpreter)

--- a/crates/python-proxy/src/main.rs
+++ b/crates/python-proxy/src/main.rs
@@ -102,6 +102,12 @@ fn main() {
     }
     command.args(env::args_os().skip(1));
     command.env("__PYVENV_LAUNCHER__", &python_proxy.proxy);
+
+    // N.B.: For Mac Python Framework builds (and Windows Python builds) __PYVENV_LAUNCHER__ is
+    // deleted from the env on launch. We need to know about the launcher in the venv `pex` script;
+    // so we duplicate that knowledge in our own env var.
+    command.env("__PEXRC_PYVENV_LAUNCHER__", &python_proxy.proxy);
+
     let lock = match cache::read_lock() {
         Ok(lock) => lock,
         Err(err) => {

--- a/crates/scripts/src/venv-pex.py
+++ b/crates/scripts/src/venv-pex.py
@@ -125,7 +125,9 @@ def boot(
 
     def sys_executable_paths():
         exe = sys.executable
-        executables = {exe}
+        # N.B.: __PEXRC_PYVENV_LAUNCHER__ is our python-proxy launcher, which is a valid venv
+        # Python to use.
+        executables = {exe, os.environ.pop("__PEXRC_PYVENV_LAUNCHER__", sys.executable)}
         while os.path.islink(exe):
             exe = os.readlink(exe)
             if not os.path.isabs(exe):

--- a/crates/tools/src/commands/venv.rs
+++ b/crates/tools/src/commands/venv.rs
@@ -3,10 +3,11 @@
 
 use std::borrow::Cow;
 use std::ffi::OsStr;
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
-use anyhow::anyhow;
+use anyhow::{anyhow, bail};
 use cache::CacheDir;
 use clap::builder::PossibleValue;
 use clap::{Args, ValueEnum};
@@ -41,20 +42,49 @@ impl ValueEnum for BinPath {
     }
 }
 
-#[derive(Clone, Eq, PartialEq, ValueEnum)]
-enum InstallScope {
-    All,
-    Deps,
-    Srcs,
-}
+#[derive(Clone)]
+struct InstallScope(venv_pex::InstallScope);
 
 impl InstallScope {
-    fn as_str(&self) -> &str {
-        match self {
-            InstallScope::All => "all",
-            InstallScope::Deps => "deps",
-            InstallScope::Srcs => "srcs",
+    fn into_inner(self) -> venv_pex::InstallScope {
+        self.0
+    }
+}
+
+impl AsRef<str> for InstallScope {
+    fn as_ref(&self) -> &str {
+        match self.0 {
+            venv_pex::InstallScope::All => "all",
+            venv_pex::InstallScope::Deps => "deps",
+            venv_pex::InstallScope::Srcs => "srcs",
         }
+    }
+}
+
+impl TryFrom<&str> for InstallScope {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &str) -> anyhow::Result<Self> {
+        Ok(Self(match value {
+            "all" => venv_pex::InstallScope::All,
+            "deps" => venv_pex::InstallScope::Deps,
+            "srcs" => venv_pex::InstallScope::Srcs,
+            _ => bail!("Not a recognized InstallScope value: {value}"),
+        }))
+    }
+}
+
+impl ValueEnum for InstallScope {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[
+            InstallScope(venv_pex::InstallScope::All),
+            InstallScope(venv_pex::InstallScope::Deps),
+            InstallScope(venv_pex::InstallScope::Srcs),
+        ]
+    }
+
+    fn to_possible_value(&self) -> Option<PossibleValue> {
+        Some(PossibleValue::new(self.0.as_str()))
     }
 }
 
@@ -67,7 +97,11 @@ enum RemoveScope {
 #[derive(Args)]
 pub(crate) struct VenvArgs {
     /// The scope of code contained in the Pex that is installed in the venv.
-    #[arg(long, value_enum, default_value_t = InstallScope::All, long_help = "\
+    #[arg(
+        long,
+        value_enum,
+        default_value_t = InstallScope(venv_pex::InstallScope::All),
+        long_help = "\
 The scope of code contained in the Pex that is installed in the venv.
 By default, all code is installed and this is generally what you want. However, in some situations
 it's beneficial to split the venv installation into deps and srcs steps. This is particularly useful
@@ -145,14 +179,82 @@ fn powershell_quote(value: &str) -> String {
     format!("'{value}'", value = value.replace("'", "''"))
 }
 
-pub(crate) fn create(python: &Path, pex: Pex, args: VenvArgs) -> anyhow::Result<()> {
-    if args.scope != InstallScope::All {
-        todo!(
-            "Support for --scope {scope} is under development.",
-            scope = args.scope.as_str()
-        );
+// @attr.s(frozen=True)
+// class InstallScopeState(object):
+//     @classmethod
+//     def load(cls, venv_dir):
+//         # type: (str) -> InstallScopeState
+//
+//         state_file = os.path.join(venv_dir, ".pex-venv-scope")
+//         prior_state = None  # type: Optional[InstallScope.Value]
+//         try:
+//             with open(state_file) as fp:
+//                 prior_state = InstallScope.for_value(fp.read().strip())
+//         except IOError as e:
+//             if e.errno != errno.ENOENT:
+//                 raise e
+//
+//         return cls(venv_dir=venv_dir, state_file=state_file, prior_state=prior_state)
+//
+//     venv_dir = attr.ib()  # type: str
+//     _state_file = attr.ib()  # type: str
+//     _prior_state = attr.ib(default=None)  # type: Optional[InstallScope.Value]
+//
+//     @property
+//     def is_partial_install(self):
+//         return self._prior_state in (InstallScope.DEPS_ONLY, InstallScope.SOURCE_ONLY)
+//
+//     def save(self, install_scope):
+//         # type: (InstallScope.Value) -> None
+//         if {InstallScope.DEPS_ONLY, InstallScope.SOURCE_ONLY} == {self._prior_state, install_scope}:
+//             install_scope = InstallScope.ALL
+//         with open(self._state_file, "w") as fp:
+//             fp.write(str(install_scope))
+
+struct InstallScopeState {
+    state_file: PathBuf,
+    prior_state: Option<InstallScope>,
+}
+
+impl InstallScopeState {
+    fn load(venv_dir: &Path) -> anyhow::Result<Self> {
+        let state_file = venv_dir.join(".pex-venv-scope");
+        let prior_state = match fs::read_to_string(&state_file) {
+            Ok(contents) => Some(InstallScope::try_from(contents.trim())?),
+            Err(err) => match err.kind() {
+                ErrorKind::NotFound => None,
+                _ => bail!("Failed to read state file from prior venv: {err}"),
+            },
+        };
+        Ok(Self {
+            state_file,
+            prior_state,
+        })
     }
 
+    fn is_partial_install(&self) -> bool {
+        matches!(
+            self.prior_state,
+            Some(InstallScope(
+                venv_pex::InstallScope::Deps | venv_pex::InstallScope::Srcs
+            ))
+        )
+    }
+
+    fn save(&self, mut install_scope: InstallScope) -> anyhow::Result<()> {
+        if let Some(prior_state) = self.prior_state.as_ref()
+            && ((prior_state.0 == venv_pex::InstallScope::Srcs
+                && install_scope.0 == venv_pex::InstallScope::Deps)
+                || (prior_state.0 == venv_pex::InstallScope::Deps
+                    && install_scope.0 == venv_pex::InstallScope::Srcs))
+        {
+            install_scope = InstallScope(venv_pex::InstallScope::All)
+        }
+        Ok(fs::write(&self.state_file, install_scope.as_ref())?)
+    }
+}
+
+pub(crate) fn create(python: &Path, pex: Pex, args: VenvArgs) -> anyhow::Result<()> {
     let search_path = SearchPath::from_env()?;
     let pex_path = PexPath::from_pex_info(&pex.info, true);
     let additional_pexes = pex_path.load_pexes()?;
@@ -163,15 +265,21 @@ pub(crate) fn create(python: &Path, pex: Pex, args: VenvArgs) -> anyhow::Result<
         fs::remove_dir_all(&args.venv_dir)?;
     }
     fs::create_dir_all(&args.venv_dir)?;
-    let venv = Virtualenv::create(
-        resolve.interpreter,
-        Cow::Borrowed(&args.venv_dir),
-        FileSystemLinker(),
-        &mut scripts,
-        args.system_site_packages,
-        args.pip,
-        args.prompt.as_deref(),
-    )?;
+
+    let install_scope_state = InstallScopeState::load(&args.venv_dir)?;
+    let venv = if install_scope_state.is_partial_install() && !args.force {
+        Virtualenv::load(Cow::Borrowed(&args.venv_dir), &mut scripts)
+    } else {
+        Virtualenv::create(
+            resolve.interpreter,
+            Cow::Borrowed(&args.venv_dir),
+            FileSystemLinker(),
+            &mut scripts,
+            args.system_site_packages,
+            args.pip,
+            args.prompt.as_deref(),
+        )
+    }?;
 
     let scripts_dir = venv.prefix().join(venv.bin_dir_relpath);
     let prompt = args
@@ -226,6 +334,7 @@ pub(crate) fn create(python: &Path, pex: Pex, args: VenvArgs) -> anyhow::Result<
         Some("-sE")
     };
 
+    let scope = args.scope.into_inner();
     venv_pex::populate(
         &venv,
         &venv.interpreter.path,
@@ -235,6 +344,7 @@ pub(crate) fn create(python: &Path, pex: Pex, args: VenvArgs) -> anyhow::Result<
         &mut scripts,
         args.bin_path.map(BinPath::into_inner),
         args.collisions_ok,
+        scope,
     )?;
     for (pex, wheels) in resolve.additional_wheels {
         venv_pex::populate_user_code_and_wheels(
@@ -245,6 +355,7 @@ pub(crate) fn create(python: &Path, pex: Pex, args: VenvArgs) -> anyhow::Result<
             wheels,
             false,
             args.collisions_ok,
+            scope,
         )?;
     }
 
@@ -277,5 +388,6 @@ pub(crate) fn create(python: &Path, pex: Pex, args: VenvArgs) -> anyhow::Result<
             }
         }
     }
+    install_scope_state.save(InstallScope(scope))?;
     Ok(())
 }

--- a/crates/tools/src/commands/venv.rs
+++ b/crates/tools/src/commands/venv.rs
@@ -179,38 +179,6 @@ fn powershell_quote(value: &str) -> String {
     format!("'{value}'", value = value.replace("'", "''"))
 }
 
-// @attr.s(frozen=True)
-// class InstallScopeState(object):
-//     @classmethod
-//     def load(cls, venv_dir):
-//         # type: (str) -> InstallScopeState
-//
-//         state_file = os.path.join(venv_dir, ".pex-venv-scope")
-//         prior_state = None  # type: Optional[InstallScope.Value]
-//         try:
-//             with open(state_file) as fp:
-//                 prior_state = InstallScope.for_value(fp.read().strip())
-//         except IOError as e:
-//             if e.errno != errno.ENOENT:
-//                 raise e
-//
-//         return cls(venv_dir=venv_dir, state_file=state_file, prior_state=prior_state)
-//
-//     venv_dir = attr.ib()  # type: str
-//     _state_file = attr.ib()  # type: str
-//     _prior_state = attr.ib(default=None)  # type: Optional[InstallScope.Value]
-//
-//     @property
-//     def is_partial_install(self):
-//         return self._prior_state in (InstallScope.DEPS_ONLY, InstallScope.SOURCE_ONLY)
-//
-//     def save(self, install_scope):
-//         # type: (InstallScope.Value) -> None
-//         if {InstallScope.DEPS_ONLY, InstallScope.SOURCE_ONLY} == {self._prior_state, install_scope}:
-//             install_scope = InstallScope.ALL
-//         with open(self._state_file, "w") as fp:
-//             fp.write(str(install_scope))
-
 struct InstallScopeState {
     state_file: PathBuf,
     prior_state: Option<InstallScope>,

--- a/crates/venv/src/lib.rs
+++ b/crates/venv/src/lib.rs
@@ -7,5 +7,5 @@
 pub mod venv_pex;
 pub mod virtualenv;
 
-pub use venv_pex::{populate, populate_user_code_and_wheels};
+pub use venv_pex::{InstallScope, populate, populate_user_code_and_wheels};
 pub use virtualenv::{Linker, Virtualenv};

--- a/crates/venv/src/venv_pex.rs
+++ b/crates/venv/src/venv_pex.rs
@@ -22,25 +22,47 @@ use zip::ZipArchive;
 
 use crate::virtualenv::Virtualenv;
 
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub enum InstallScope {
+    All,
+    Deps,
+    Srcs,
+}
+
+impl InstallScope {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            InstallScope::All => "all",
+            InstallScope::Deps => "deps",
+            InstallScope::Srcs => "srcs",
+        }
+    }
+}
+
 fn populate_from_loose_pex<'a>(
     venv: &Virtualenv,
     loose_pex: &'a Pex<'a>,
     resolved_wheels: &IndexMap<&'a str, ResolvedWheel<'a>>,
     populate_pex_info: bool,
     collisions_ok: bool,
+    scope: InstallScope,
 ) -> anyhow::Result<()> {
     let site_packages_path = venv.site_packages_path();
-    collect_wheels_from_directory_pex(loose_pex, resolved_wheels)?
-        .into_par_iter()
-        .try_for_each(|wheel_dir| {
-            populate_wheel_dir(&wheel_dir, &site_packages_path, collisions_ok)
-        })?;
-    populate_user_code_from_directory_pex(
-        loose_pex,
-        venv.prefix(),
-        &site_packages_path,
-        populate_pex_info,
-    )?;
+    if matches!(scope, InstallScope::All | InstallScope::Deps) {
+        collect_wheels_from_directory_pex(loose_pex, resolved_wheels)?
+            .into_par_iter()
+            .try_for_each(|wheel_dir| {
+                populate_wheel_dir(&wheel_dir, &site_packages_path, collisions_ok)
+            })?;
+    }
+    if matches!(scope, InstallScope::All | InstallScope::Srcs) {
+        populate_user_code_from_directory_pex(
+            loose_pex,
+            venv,
+            &site_packages_path,
+            populate_pex_info,
+        )?;
+    }
     Ok(())
 }
 
@@ -237,7 +259,9 @@ fn create_script_contents(
     let shebang = RenderShebang(path_as_str(shebang_interpreter)?, shebang_arg);
 
     let mut components = entry_point.splitn(2, ":");
-    let modname = components.next().ok_or_else(|| anyhow!("XXX"))?;
+    let modname = components
+        .next()
+        .expect("A split always yield at least one item.");
     if let Some(attrs) = components.next()
         && !attrs.is_empty()
     {
@@ -335,19 +359,24 @@ fn populate_from_packed_pex<'a>(
     resolved_wheels: &IndexMap<&'a str, ResolvedWheel<'a>>,
     populate_pex_info: bool,
     collisions_ok: bool,
+    scope: InstallScope,
 ) -> anyhow::Result<()> {
     let site_packages_path = venv.site_packages_path();
-    collect_wheels_from_directory_pex(packed_pex, resolved_wheels)?
-        .into_par_iter()
-        .try_for_each(|wheel_zip| {
-            populate_whl_zip(&wheel_zip, &site_packages_path, collisions_ok)
-        })?;
-    populate_user_code_from_directory_pex(
-        packed_pex,
-        venv.prefix(),
-        &site_packages_path,
-        populate_pex_info,
-    )?;
+    if matches!(scope, InstallScope::All | InstallScope::Deps) {
+        collect_wheels_from_directory_pex(packed_pex, resolved_wheels)?
+            .into_par_iter()
+            .try_for_each(|wheel_zip| {
+                populate_whl_zip(&wheel_zip, &site_packages_path, collisions_ok)
+            })?;
+    }
+    if matches!(scope, InstallScope::All | InstallScope::Srcs) {
+        populate_user_code_from_directory_pex(
+            packed_pex,
+            venv,
+            &site_packages_path,
+            populate_pex_info,
+        )?;
+    }
     Ok(())
 }
 
@@ -367,7 +396,7 @@ fn populate_whl_zip(
 
 fn populate_user_code_from_directory_pex<'a>(
     directory_pex: &'a Pex<'a>,
-    venv_dir: &Path,
+    venv: &Virtualenv,
     site_packages_path: &Path,
     populate_pex_info: bool,
 ) -> anyhow::Result<()> {
@@ -383,11 +412,6 @@ fn populate_user_code_from_directory_pex<'a>(
     .into_iter()
     .map(|rel_path| directory_pex.path.join(rel_path))
     .collect();
-    let _pex_info_exclude = if populate_pex_info {
-        None
-    } else {
-        Some(directory_pex.path.join("PEX-INFO"))
-    };
     let user_code = walkdir::WalkDir::new(directory_pex.path)
         .min_depth(1)
         .into_iter()
@@ -407,11 +431,10 @@ fn populate_user_code_from_directory_pex<'a>(
             fs::copy(entry.path(), dst_path).map(|_| ())
         }
     })?;
-
     if populate_pex_info {
         fs::copy(
             directory_pex.path.join("PEX-INFO"),
-            venv_dir.join("PEX-INFO"),
+            venv.prefix().join("PEX-INFO"),
         )?;
     }
     Ok(())
@@ -423,62 +446,88 @@ fn populate_from_zip_app_with_whl_deps<'a>(
     resolved_wheels: &IndexMap<&'a str, ResolvedWheel<'a>>,
     populate_pex_info: bool,
     collisions_ok: bool,
+    scope: InstallScope,
 ) -> anyhow::Result<()> {
     let pex_zip = ZipArchive::new(File::open(zip_app_pex.path)?)?;
     let metadata = pex_zip.metadata();
-    let extract_indexes = pex_zip
-        .file_names()
-        .enumerate()
-        .filter_map(|(idx, name)| {
-            if [".deps/", "__pex__/"]
-                .iter()
-                .any(|exclude_dir| name.starts_with(exclude_dir))
-                || ["PEX-INFO", "__main__.py"].contains(&name)
-            {
-                None
-            } else {
-                Some(idx)
-            }
-        })
-        .collect::<Vec<_>>();
     let site_packages_path = venv.site_packages_path();
-    extract_indexes
-        .into_par_iter()
-        .try_for_each(|index| -> anyhow::Result<()> {
-            let zip_fp = File::open(zip_app_pex.path)?;
-            let mut zip = unsafe { ZipArchive::unsafe_new_with_metadata(zip_fp, metadata.clone()) };
-            extract_idx(&site_packages_path, index, &mut zip, collisions_ok)?;
-            Ok(())
-        })?;
 
-    let wheel_file_names = resolved_wheels.into_iter().collect::<Vec<_>>();
-    wheel_file_names
-        .into_par_iter()
-        .try_for_each(|(wheel_file_name, _)| {
-            let zip_fp = File::open(zip_app_pex.path)?;
-            let mut zip = unsafe { ZipArchive::unsafe_new_with_metadata(zip_fp, metadata.clone()) };
-            let whl_file = zip.by_name_seek(&[".deps", wheel_file_name].join("/"))?;
-            let whl_zip = ZipArchive::new(whl_file)?;
-            let whl_zip_metadata = whl_zip.metadata();
-            (0..whl_zip.len()).into_par_iter().try_for_each(|index| {
+    if matches!(scope, InstallScope::All | InstallScope::Deps) {
+        let wheel_file_names = resolved_wheels.into_iter().collect::<Vec<_>>();
+        wheel_file_names
+            .into_par_iter()
+            .try_for_each(|(wheel_file_name, _)| {
                 let zip_fp = File::open(zip_app_pex.path)?;
                 let mut zip =
                     unsafe { ZipArchive::unsafe_new_with_metadata(zip_fp, metadata.clone()) };
                 let whl_file = zip.by_name_seek(&[".deps", wheel_file_name].join("/"))?;
-                let mut whl_zip = unsafe {
-                    ZipArchive::unsafe_new_with_metadata(whl_file, whl_zip_metadata.clone())
-                };
-                extract_idx(&site_packages_path, index, &mut whl_zip, collisions_ok)
+                let whl_zip = ZipArchive::new(whl_file)?;
+                let whl_zip_metadata = whl_zip.metadata();
+                (0..whl_zip.len()).into_par_iter().try_for_each(|index| {
+                    let zip_fp = File::open(zip_app_pex.path)?;
+                    let mut zip =
+                        unsafe { ZipArchive::unsafe_new_with_metadata(zip_fp, metadata.clone()) };
+                    let whl_file = zip.by_name_seek(&[".deps", wheel_file_name].join("/"))?;
+                    let mut whl_zip = unsafe {
+                        ZipArchive::unsafe_new_with_metadata(whl_file, whl_zip_metadata.clone())
+                    };
+                    extract_idx(&site_packages_path, index, &mut whl_zip, collisions_ok)
+                })
+            })?;
+    }
+    if matches!(scope, InstallScope::All | InstallScope::Srcs) {
+        let extract_indexes = pex_zip
+            .file_names()
+            .enumerate()
+            .filter_map(|(idx, name)| {
+                if [".deps/", "__pex__/"]
+                    .iter()
+                    .any(|exclude_dir| name.starts_with(exclude_dir))
+                    || ["PEX-INFO", "__main__.py"].contains(&name)
+                {
+                    None
+                } else {
+                    Some(idx)
+                }
             })
-        })?;
-
-    if populate_pex_info {
-        let mut pex_zip = ZipArchive::new(File::open(zip_app_pex.path)?)?;
-        let mut pex_info_src_fp = pex_zip.by_name("PEX-INFO")?;
-        let mut pex_info_dst_fp = File::create_new(venv.prefix().join("PEX-INFO"))?;
-        io::copy(&mut pex_info_src_fp, &mut pex_info_dst_fp)?;
+            .collect::<Vec<_>>();
+        extract_indexes
+            .into_par_iter()
+            .try_for_each(|index| -> anyhow::Result<()> {
+                let zip_fp = File::open(zip_app_pex.path)?;
+                let mut zip =
+                    unsafe { ZipArchive::unsafe_new_with_metadata(zip_fp, metadata.clone()) };
+                extract_idx(&site_packages_path, index, &mut zip, collisions_ok)?;
+                Ok(())
+            })?;
+        if populate_pex_info {
+            let mut pex_zip = ZipArchive::new(File::open(zip_app_pex.path)?)?;
+            let mut pex_info_src_fp = pex_zip.by_name("PEX-INFO")?;
+            let mut pex_info_dst_fp = File::create(venv.prefix().join("PEX-INFO"))?;
+            io::copy(&mut pex_info_src_fp, &mut pex_info_dst_fp)?;
+        }
     }
     Ok(())
+}
+
+struct DepFilter<'a>(&'a IndexMap<&'a str, ResolvedWheel<'a>>);
+
+impl<'a> DepFilter<'a> {
+    fn filter_deps(&self, file_name: &str) -> bool {
+        file_name.starts_with(".deps/")
+            && file_name[6..]
+                .split("/")
+                .next()
+                .map(|whl_name| self.0.contains_key(whl_name))
+                .unwrap_or_default()
+    }
+}
+
+fn filter_srcs(file_name: &str) -> bool {
+    ![".deps/", "__pex__/"]
+        .iter()
+        .any(|dir_prefix| file_name.starts_with(dir_prefix))
+        && ![".deps/", "__pex__/", "PEX-INFO", "__main__.py"].contains(&file_name)
 }
 
 fn populate_from_zip_app<'a>(
@@ -487,26 +536,24 @@ fn populate_from_zip_app<'a>(
     resolved_wheels: &IndexMap<&'a str, ResolvedWheel<'a>>,
     populate_pex_info: bool,
     collisions_ok: bool,
+    scope: InstallScope,
 ) -> anyhow::Result<()> {
     let mut pex_zip = ZipArchive::new(File::open(zip_app_pex.path)?)?;
     let metadata = pex_zip.metadata();
+    let dep_filter = DepFilter(resolved_wheels);
     let extract_indexes = pex_zip
         .file_names()
         .enumerate()
         .filter_map(|(idx, name)| {
             // TODO: XXX: Deal with .layout and .prefix/ in wheel chroots.
-            if name.starts_with("__pex__/")
-                || [".deps/", "PEX-INFO", "__main__.py"].contains(&name)
-                || name.starts_with(".deps/")
-                    && name[6..]
-                        .split("/")
-                        .next()
-                        .map(|whl_name| !resolved_wheels.contains_key(whl_name))
-                        .unwrap_or(true)
-            {
-                None
-            } else {
+            if match scope {
+                InstallScope::All => dep_filter.filter_deps(name) || filter_srcs(name),
+                InstallScope::Deps => dep_filter.filter_deps(name),
+                InstallScope::Srcs => filter_srcs(name),
+            } {
                 Some(idx)
+            } else {
+                None
             }
         })
         .collect::<Vec<_>>();
@@ -519,14 +566,15 @@ fn populate_from_zip_app<'a>(
             extract_idx(&site_packages_path, index, &mut zip, collisions_ok)?;
             Ok(())
         })?;
-    if populate_pex_info {
+    if populate_pex_info && matches!(scope, InstallScope::All | InstallScope::Srcs) {
         let mut pex_info_src_fp = pex_zip.by_name("PEX-INFO")?;
-        let mut pex_info_dst_fp = File::create_new(venv.prefix().join("PEX-INFO"))?;
+        let mut pex_info_dst_fp = File::create(venv.prefix().join("PEX-INFO"))?;
         io::copy(&mut pex_info_src_fp, &mut pex_info_dst_fp)?;
     }
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 #[time("debug", "{}")]
 pub fn populate_user_code_and_wheels<'a>(
     venv: &Virtualenv,
@@ -536,6 +584,7 @@ pub fn populate_user_code_and_wheels<'a>(
     resolved_wheels: IndexMap<&'a str, ResolvedWheel<'a>>,
     populate_pex_info: bool,
     collisions_ok: bool,
+    scope: InstallScope,
 ) -> anyhow::Result<()> {
     match pex.layout {
         Layout::Loose => populate_from_loose_pex(
@@ -544,6 +593,7 @@ pub fn populate_user_code_and_wheels<'a>(
             &resolved_wheels,
             populate_pex_info,
             collisions_ok,
+            scope,
         )?,
         Layout::Packed => populate_from_packed_pex(
             venv,
@@ -551,6 +601,7 @@ pub fn populate_user_code_and_wheels<'a>(
             &resolved_wheels,
             populate_pex_info,
             collisions_ok,
+            scope,
         )?,
         Layout::ZipApp => {
             if pex.info.deps_are_wheel_files {
@@ -560,6 +611,7 @@ pub fn populate_user_code_and_wheels<'a>(
                     &resolved_wheels,
                     populate_pex_info,
                     collisions_ok,
+                    scope,
                 )?
             } else {
                 populate_from_zip_app(
@@ -568,24 +620,27 @@ pub fn populate_user_code_and_wheels<'a>(
                     &resolved_wheels,
                     populate_pex_info,
                     collisions_ok,
+                    scope,
                 )?
             }
         }
     }
-    resolved_wheels
-        .into_values()
-        .collect::<Vec<_>>()
-        .into_par_iter()
-        .try_for_each(|resolved_wheel| {
-            spread(
-                pex,
-                resolved_wheel,
-                venv,
-                shebang_interpreter,
-                shebang_arg,
-                collisions_ok,
-            )
-        })?;
+    if matches!(scope, InstallScope::All | InstallScope::Deps) {
+        resolved_wheels
+            .into_values()
+            .collect::<Vec<_>>()
+            .into_par_iter()
+            .try_for_each(|resolved_wheel| {
+                spread(
+                    pex,
+                    resolved_wheel,
+                    venv,
+                    shebang_interpreter,
+                    shebang_arg,
+                    collisions_ok,
+                )
+            })?;
+    }
     Ok(())
 }
 
@@ -600,6 +655,7 @@ pub fn populate<'a>(
     scripts: &mut Scripts,
     bin_path_override: Option<BinPath>,
     collisions_ok: bool,
+    scope: InstallScope,
 ) -> anyhow::Result<()> {
     let selected_wheels = resolved_wheels.keys().copied().collect::<Vec<_>>();
     populate_user_code_and_wheels(
@@ -610,25 +666,28 @@ pub fn populate<'a>(
         resolved_wheels,
         true,
         collisions_ok,
+        scope,
     )?;
-
-    write_main(
-        venv,
-        shebang_interpreter,
-        shebang_arg,
-        &pex.info,
-        scripts,
-        bin_path_override,
-    )?;
-    write_repl(
-        venv,
-        shebang_interpreter,
-        shebang_arg,
-        pex.path,
-        &pex.info,
-        selected_wheels,
-        scripts,
-    )
+    if matches!(scope, InstallScope::All | InstallScope::Srcs) {
+        write_main(
+            venv,
+            shebang_interpreter,
+            shebang_arg,
+            &pex.info,
+            scripts,
+            bin_path_override,
+        )?;
+        write_repl(
+            venv,
+            shebang_interpreter,
+            shebang_arg,
+            pex.path,
+            &pex.info,
+            selected_wheels,
+            scripts,
+        )?;
+    }
+    Ok(())
 }
 
 fn extract_idx<R>(


### PR DESCRIPTION
Only provenance tracking for venv collisions remains, but this was
also already outstanding for regular PEXrc executions (as warnings).