### PR TITLE
Ensure venv Pex tool creates Python symlinks.

### DIFF
--- a/crates/tools/src/commands/venv.rs
+++ b/crates/tools/src/commands/venv.rs
@@ -236,9 +236,9 @@ pub(crate) fn create(python: &Path, pex: Pex, args: VenvArgs) -> anyhow::Result<
 
     let install_scope_state = InstallScopeState::load(&args.venv_dir)?;
     let venv = if install_scope_state.is_partial_install() && !args.force {
-        Virtualenv::load(Cow::Borrowed(&args.venv_dir), &mut scripts)
+        Virtualenv::load(Cow::Borrowed(&args.venv_dir), &mut scripts)?
     } else {
-        Virtualenv::create(
+        let venv = Virtualenv::create(
             resolve.interpreter,
             Cow::Borrowed(&args.venv_dir),
             FileSystemLinker(),
@@ -246,8 +246,11 @@ pub(crate) fn create(python: &Path, pex: Pex, args: VenvArgs) -> anyhow::Result<
             args.system_site_packages,
             args.pip,
             args.prompt.as_deref(),
-        )
-    }?;
+        )?;
+        #[cfg(unix)]
+        venv.create_additional_python_links()?;
+        venv
+    };
 
     let scripts_dir = venv.prefix().join(venv.bin_dir_relpath);
     let prompt = args

--- a/crates/venv/src/virtualenv.rs
+++ b/crates/venv/src/virtualenv.rs
@@ -35,6 +35,34 @@ fn executable_rel_path(interpreter: &Interpreter) -> Cow<'static, str> {
     }
 }
 
+#[cfg(unix)]
+fn additional_executable_rel_paths(interpreter: &Interpreter) -> Vec<Cow<'static, str>> {
+    let mut rel_paths: Vec<Cow<'static, str>> =
+        Vec::with_capacity(if interpreter.pypy_version.is_some() {
+            5
+        } else {
+            2
+        });
+    if interpreter.pypy_version.is_some() {
+        rel_paths.push(Cow::Owned(format!(
+            "{SCRIPTS_DIR}/pypy{major}",
+            major = interpreter.version.major,
+        )));
+        rel_paths.push(Cow::Borrowed("bin/pypy"));
+        rel_paths.push(Cow::Owned(format!(
+            "{SCRIPTS_DIR}/python{major}.{minor}",
+            major = interpreter.version.major,
+            minor = interpreter.version.minor
+        )));
+    }
+    rel_paths.push(Cow::Owned(format!(
+        "{SCRIPTS_DIR}/python{major}",
+        major = interpreter.version.major,
+    )));
+    rel_paths.push(Cow::Borrowed("bin/python"));
+    rel_paths
+}
+
 #[cfg(windows)]
 const SCRIPTS_DIR: &str = "Scripts";
 
@@ -160,6 +188,17 @@ impl<'a> Virtualenv<'a> {
 
     pub fn site_packages_path(&self) -> PathBuf {
         self.interpreter.prefix.join(&self.site_packages_relpath)
+    }
+
+    #[cfg(unix)]
+    pub fn create_additional_python_links(&self) -> anyhow::Result<()> {
+        for rel_path in additional_executable_rel_paths(&self.interpreter) {
+            let dest = self.interpreter.prefix.join(rel_path.as_ref());
+            if !dest.exists() {
+                symlink_or_link_or_copy(&self.interpreter.path, dest, true)?;
+            }
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
On unix, the full expected set of Python symlinks is now created.