### PR TITLE
Infrastructure to extract zstd whls from PEXes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,7 +338,7 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -541,6 +547,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -997,6 +1024,12 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1712,6 +1745,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ouroboros"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0f050db9c44b97a94723127e6be766ac5c340c48f2c4bb3ffa11713744be59"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+ "static_assertions",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c7028bdd3d43083f6d8d4d5187680d0d3560d54df4cc9d752005268b41e64d0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1845,6 +1902,7 @@ name = "pex"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "csv",
  "dashmap",
  "fs-err",
  "glob",
@@ -1853,18 +1911,22 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "logging_timer",
+ "ouroboros",
  "pep440_rs",
  "pep508_rs",
  "python-pkginfo",
  "rayon",
  "rstest",
+ "rust-ini",
  "scripts",
  "serde",
  "serde_json",
  "strum",
  "strum_macros",
+ "tempfile",
  "testing",
  "url",
+ "walkdir",
  "zip",
 ]
 
@@ -2018,6 +2080,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -2487,6 +2562,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2697,6 +2778,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2717,7 +2804,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3744,7 +3831,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "wit-parser",
 ]
 
@@ -3755,7 +3842,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "indexmap",
  "prettyplease",
  "syn 2.0.117",
@@ -3840,6 +3927,12 @@ checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
 dependencies = [
  "lzma-sys",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,7 @@ clap = {  version = "4.6", features = ["color", "derive", "string"] }
 clap-verbosity-flag = "3.0"
 colorchoice-clap = "1.0"
 const_format = { version = "0.2", features = ["rust_1_64"] }
+csv = "1.4"
 ctor = "0.10"
 dashmap = "6.1"
 digest = "0.11"
@@ -129,6 +130,7 @@ log = "0.4"
 logging_timer = "1.1"
 nix = {  version = "0.31", features = ["fs"] }
 open = "5.3"
+ouroboros = "0.18"
 owo-colors = "4.3"
 pathdiff = "0.2"
 pep440_rs = "0.7"

--- a/crates/pex/Cargo.toml
+++ b/crates/pex/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
+csv = { workspace = true }
 dashmap = { workspace = true }
 fs-err = { workspace = true }
 indexmap = { workspace = true }
@@ -15,16 +16,20 @@ interpreter = { path = "../interpreter" }
 itertools = { workspace = true }
 log = { workspace = true }
 logging_timer = { workspace = true }
+ouroboros = { workspace = true }
 pep440_rs = { workspace = true }
 pep508_rs = { workspace = true }
 python-pkginfo = { workspace = true }
 rayon = { workspace = true }
+rust-ini = { workspace = true }
 scripts = { path = "../scripts" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
+tempfile = { workspace = true }
 url = { workspace = true }
+walkdir = { workspace = true }
 zip = { workspace = true }
 
 [dev-dependencies]

--- a/crates/pex/src/lib.rs
+++ b/crates/pex/src/lib.rs
@@ -19,4 +19,4 @@ pub use pex::{
 };
 pub use pex_info::{BinPath, InheritPath, InterpreterSelectionStrategy, PexInfo};
 pub use pex_path::PexPath;
-pub use wheel::WheelMetadata;
+pub use wheel::{EntryPoint, EntryPoints, WheelMetadata, repackage_wheels};

--- a/crates/pex/src/pex.rs
+++ b/crates/pex/src/pex.rs
@@ -30,7 +30,7 @@ use zip::ZipArchive;
 use crate::PexInfo;
 use crate::wheel::{MetadataReader, WheelFile, WheelMetadata};
 
-#[derive(AsRefStr, EnumString)]
+#[derive(AsRefStr, EnumString, Eq, PartialEq)]
 pub enum Layout {
     #[strum(serialize = "loose")]
     Loose,

--- a/crates/pex/src/wheel/entry_points.rs
+++ b/crates/pex/src/wheel/entry_points.rs
@@ -1,0 +1,113 @@
+// Copyright 2026 Pex project contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+use std::fmt::{Display, Formatter};
+use std::io::Read;
+
+use ini::Ini;
+use ouroboros::self_referencing;
+
+pub enum EntryPoint<'a> {
+    Module(&'a str),
+    Callable {
+        module: &'a str,
+        attribute_chain: &'a str,
+    },
+}
+
+impl<'a> EntryPoint<'a> {
+    fn parse(value: &'a str) -> Self {
+        let mut components = value.splitn(2, ":");
+        let module = components
+            .next()
+            .expect("A split always yield at least one item.");
+        if let Some(attribute_chain) = components.next()
+            && !attribute_chain.is_empty()
+        {
+            Self::Callable {
+                module,
+                attribute_chain,
+            }
+        } else {
+            Self::Module(module)
+        }
+    }
+}
+
+impl<'a> Display for EntryPoint<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EntryPoint::Module(module) => write!(f, "{module}"),
+            EntryPoint::Callable {
+                module,
+                attribute_chain,
+            } => write!(f, "{module}:{attribute_chain}"),
+        }
+    }
+}
+
+#[self_referencing]
+pub struct EntryPoints {
+    contents: Ini,
+
+    #[borrows(contents)]
+    #[covariant]
+    console_scripts: HashMap<&'this str, EntryPoint<'this>>,
+
+    #[borrows(contents)]
+    #[covariant]
+    gui_scripts: HashMap<&'this str, EntryPoint<'this>>,
+}
+
+impl EntryPoints {
+    pub fn empty() -> Self {
+        EntryPointsBuilder {
+            contents: Ini::new(),
+            console_scripts_builder: |_| HashMap::new(),
+            gui_scripts_builder: |_| HashMap::new(),
+        }
+        .build()
+    }
+
+    pub fn load(mut contents: impl Read) -> anyhow::Result<Self> {
+        Ok(EntryPointsBuilder {
+            contents: Ini::read_from(&mut contents)?,
+            console_scripts_builder: |contents| parse_entry_points(contents, "console_scripts"),
+            gui_scripts_builder: |contents| parse_entry_points(contents, "gui_scripts"),
+        }
+        .build())
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.borrow_console_scripts().is_empty() && self.borrow_gui_scripts().is_empty()
+    }
+
+    pub fn is_script(&self, name: impl AsRef<str>) -> bool {
+        self.borrow_console_scripts().contains_key(name.as_ref())
+            || self.borrow_gui_scripts().contains_key(name.as_ref())
+    }
+
+    pub fn console_scripts(&self) -> impl Iterator<Item = (&str, &EntryPoint<'_>)> {
+        self.borrow_console_scripts()
+            .iter()
+            .map(|(name, entry_point)| (*name, entry_point))
+    }
+
+    pub fn gui_scripts(&self) -> impl Iterator<Item = (&str, &EntryPoint<'_>)> {
+        self.borrow_gui_scripts()
+            .iter()
+            .map(|(name, entry_point)| (*name, entry_point))
+    }
+}
+
+fn parse_entry_points<'a>(ini: &'a Ini, section_name: &str) -> HashMap<&'a str, EntryPoint<'a>> {
+    ini.section(Some(section_name))
+        .map(|section| {
+            section
+                .iter()
+                .map(|(name, entry_point)| (name, EntryPoint::parse(entry_point)))
+                .collect::<HashMap<_, _>>()
+        })
+        .unwrap_or_default()
+}

--- a/crates/pex/src/wheel/file.rs
+++ b/crates/pex/src/wheel/file.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::fmt::{Display, Formatter, Write};
+use std::path::PathBuf;
 use std::str::FromStr;
 
 use anyhow::{anyhow, bail};
@@ -86,6 +87,27 @@ impl<'a> WheelFile<'a> {
             build_tag,
             tags,
         })
+    }
+
+    pub fn data_dir(&self) -> PathBuf {
+        self.pnav_dir("data")
+    }
+
+    pub fn dist_info_dir(&self) -> PathBuf {
+        self.pnav_dir("dist-info")
+    }
+
+    pub fn pex_info_info_dir(&self) -> PathBuf {
+        self.pnav_dir("pex-info")
+    }
+
+    fn pnav_dir(&self, name: &str) -> PathBuf {
+        format!(
+            "{project_name}-{version}.{name}",
+            project_name = self.raw_project_name,
+            version = self.raw_version
+        )
+        .into()
     }
 
     fn write_tag_component(

--- a/crates/pex/src/wheel/file.rs
+++ b/crates/pex/src/wheel/file.rs
@@ -7,10 +7,8 @@ use std::str::FromStr;
 use anyhow::{anyhow, bail};
 use indexmap::IndexSet;
 use interpreter::Tag;
-use pep440_rs::{Version, VersionSpecifiers};
-use pep508_rs::{PackageName, Requirement};
-use python_pkginfo::Metadata;
-use url::Url;
+use pep440_rs::Version;
+use pep508_rs::PackageName;
 
 pub struct WheelFile<'a> {
     pub(crate) file_name: &'a str,
@@ -131,80 +129,15 @@ impl<'a> Display for WheelFile<'a> {
     }
 }
 
-pub struct WheelMetadata<'a> {
-    pub file_name: &'a str,
-    pub raw_project_name: &'a str,
-    pub project_name: PackageName,
-    pub raw_version: &'a str,
-    pub version: Version,
-    pub requires_dists: Vec<Requirement<Url>>,
-    pub requires_python: Option<VersionSpecifiers>,
-}
-
-pub trait MetadataReader<'a> {
-    fn read(
-        &mut self,
-        wheel_file_name: &'a str,
-        path_components: &[&str],
-    ) -> anyhow::Result<String>;
-}
-
-impl<'a> WheelMetadata<'a> {
-    pub fn parse(
-        wheel_file: WheelFile<'a>,
-        metadata_reader: &mut impl MetadataReader<'a>,
-    ) -> anyhow::Result<Self> {
-        let dist_info_dir = format!(
-            "{project_name}-{version}.dist-info",
-            project_name = wheel_file.raw_project_name,
-            version = wheel_file.raw_version
-        );
-        let components = [&dist_info_dir, "METADATA"];
-        let metadata = Metadata::parse(
-            metadata_reader
-                .read(wheel_file.file_name, &components)?
-                .as_bytes(),
-        )?;
-        let mut requires_dists: Vec<Requirement<Url>> =
-            Vec::with_capacity(metadata.requires_dist.len());
-        for requires_dist in metadata.requires_dist {
-            requires_dists.push(Requirement::from_str(&requires_dist)?)
-        }
-        let requires_python = if let Some(requires_python) = metadata.requires_python {
-            Some(VersionSpecifiers::from_str(&requires_python)?)
-        } else {
-            None
-        };
-
-        Ok(Self {
-            file_name: wheel_file.file_name,
-            raw_project_name: wheel_file.raw_project_name,
-            project_name: wheel_file.project_name,
-            raw_version: wheel_file.raw_version,
-            version: wheel_file.version,
-            requires_dists,
-            requires_python,
-        })
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use std::ffi::OsStr;
-    use std::io;
-    use std::path::{Path, PathBuf};
-    use std::process::Command;
     use std::str::FromStr;
 
-    use fs_err::File;
     use interpreter::Tag;
-    use pep440_rs::{Version, VersionSpecifiers};
-    use pep508_rs::{PackageName, Requirement};
-    use rstest::*;
-    use testing::{tmp_dir, venv_python_exe};
-    use zip::ZipArchive;
+    use pep440_rs::Version;
+    use pep508_rs::PackageName;
 
-    use crate::wheel::{MetadataReader, WheelFile, WheelMetadata};
+    use crate::wheel::file::WheelFile;
 
     #[test]
     fn test_parse_wheel_file_name_simple() {
@@ -280,80 +213,5 @@ mod tests {
             }],
             wheel_file.tags
         )
-    }
-
-    #[fixture]
-    #[once]
-    fn requests_2_32_5_whl(tmp_dir: PathBuf, venv_python_exe: PathBuf) -> PathBuf {
-        let wheel_dir = tmp_dir.join("wheels");
-        assert!(
-            Command::new(venv_python_exe)
-                .args([
-                    "-m",
-                    "pip",
-                    "download",
-                    "--no-deps",
-                    "--only-binary",
-                    ":all:",
-                    "--dest",
-                ])
-                .arg(&wheel_dir)
-                .arg("requests==2.32.5")
-                .spawn()
-                .unwrap()
-                .wait()
-                .unwrap()
-                .success()
-        );
-        let mut matches = glob::glob(wheel_dir.join("*.whl").to_str().unwrap()).unwrap();
-        let wheel = matches.next().unwrap();
-        assert!(matches.next().is_none());
-        wheel.unwrap()
-    }
-
-    #[rstest]
-    fn test_parse_wheel_chroot(requests_2_32_5_whl: &Path) {
-        let file_name = requests_2_32_5_whl
-            .file_name()
-            .and_then(OsStr::to_str)
-            .unwrap();
-        let wheel_file = WheelFile::parse_file_name(file_name).unwrap();
-        assert_eq!("requests", wheel_file.raw_project_name);
-        assert_eq!("2.32.5", wheel_file.raw_version);
-
-        struct RequestsMetadataReader(ZipArchive<File>);
-        impl<'a> MetadataReader<'a> for RequestsMetadataReader {
-            fn read(&mut self, _: &str, path_components: &[&str]) -> anyhow::Result<String> {
-                Ok(io::read_to_string(
-                    self.0.by_name(&path_components.join("/"))?,
-                )?)
-            }
-        }
-        let mut metadata_reader = RequestsMetadataReader(
-            ZipArchive::new(File::open(requests_2_32_5_whl).unwrap()).unwrap(),
-        );
-
-        let wheel = WheelMetadata::parse(wheel_file, &mut metadata_reader).unwrap();
-        assert_eq!(
-            PackageName::new("requests".into()).unwrap(),
-            wheel.project_name
-        );
-        assert_eq!(Version::new([2, 32, 5]), wheel.version);
-        assert_eq!(
-            Some(VersionSpecifiers::from_str(">=3.9").unwrap()),
-            wheel.requires_python
-        );
-        assert_eq!(
-            vec![
-                Requirement::from_str("charset_normalizer<4,>=2").unwrap(),
-                Requirement::from_str("idna<4,>=2.5").unwrap(),
-                Requirement::from_str("urllib3<3,>=1.21.1").unwrap(),
-                Requirement::from_str("certifi>=2017.4.17").unwrap(),
-                Requirement::from_str("PySocks!=1.5.7,>=1.5.6; extra == \"socks\"").unwrap(),
-                Requirement::from_str("chardet<6,>=3.0.2; extra == \"use-chardet-on-py3\"")
-                    .unwrap(),
-            ],
-            wheel.requires_dists
-        );
     }
 }

--- a/crates/pex/src/wheel/metadata.rs
+++ b/crates/pex/src/wheel/metadata.rs
@@ -1,0 +1,162 @@
+// Copyright 2026 Pex project contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::str::FromStr;
+
+use pep440_rs::{Version, VersionSpecifiers};
+use pep508_rs::{PackageName, Requirement};
+use python_pkginfo::Metadata;
+use url::Url;
+
+use crate::wheel::file::WheelFile;
+
+pub struct WheelMetadata<'a> {
+    pub file_name: &'a str,
+    pub raw_project_name: &'a str,
+    pub project_name: PackageName,
+    pub raw_version: &'a str,
+    pub version: Version,
+    pub requires_dists: Vec<Requirement<Url>>,
+    pub requires_python: Option<VersionSpecifiers>,
+}
+
+pub(crate) trait MetadataReader<'a> {
+    fn read(
+        &mut self,
+        wheel_file_name: &'a str,
+        path_components: &[&str],
+    ) -> anyhow::Result<String>;
+}
+
+impl<'a> WheelMetadata<'a> {
+    pub(crate) fn parse(
+        wheel_file: WheelFile<'a>,
+        metadata_reader: &mut impl MetadataReader<'a>,
+    ) -> anyhow::Result<Self> {
+        let dist_info_dir = format!(
+            "{project_name}-{version}.dist-info",
+            project_name = wheel_file.raw_project_name,
+            version = wheel_file.raw_version
+        );
+        let components = [&dist_info_dir, "METADATA"];
+        let metadata = Metadata::parse(
+            metadata_reader
+                .read(wheel_file.file_name, &components)?
+                .as_bytes(),
+        )?;
+        let mut requires_dists: Vec<Requirement<Url>> =
+            Vec::with_capacity(metadata.requires_dist.len());
+        for requires_dist in metadata.requires_dist {
+            requires_dists.push(Requirement::from_str(&requires_dist)?)
+        }
+        let requires_python = if let Some(requires_python) = metadata.requires_python {
+            Some(VersionSpecifiers::from_str(&requires_python)?)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            file_name: wheel_file.file_name,
+            raw_project_name: wheel_file.raw_project_name,
+            project_name: wheel_file.project_name,
+            raw_version: wheel_file.raw_version,
+            version: wheel_file.version,
+            requires_dists,
+            requires_python,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsStr;
+    use std::io;
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+    use std::str::FromStr;
+
+    use fs_err::File;
+    use pep440_rs::{Version, VersionSpecifiers};
+    use pep508_rs::{PackageName, Requirement};
+    use rstest::*;
+    use testing::{tmp_dir, venv_python_exe};
+    use zip::ZipArchive;
+
+    use crate::wheel::file::WheelFile;
+    use crate::wheel::metadata::{MetadataReader, WheelMetadata};
+
+    #[fixture]
+    #[once]
+    fn requests_2_32_5_whl(tmp_dir: PathBuf, venv_python_exe: PathBuf) -> PathBuf {
+        let wheel_dir = tmp_dir.join("wheels");
+        assert!(
+            Command::new(venv_python_exe)
+                .args([
+                    "-m",
+                    "pip",
+                    "download",
+                    "--no-deps",
+                    "--only-binary",
+                    ":all:",
+                    "--dest",
+                ])
+                .arg(&wheel_dir)
+                .arg("requests==2.32.5")
+                .spawn()
+                .unwrap()
+                .wait()
+                .unwrap()
+                .success()
+        );
+        let mut matches = glob::glob(wheel_dir.join("*.whl").to_str().unwrap()).unwrap();
+        let wheel = matches.next().unwrap();
+        assert!(matches.next().is_none());
+        wheel.unwrap()
+    }
+
+    #[rstest]
+    fn test_parse_wheel_chroot(requests_2_32_5_whl: &Path) {
+        let file_name = requests_2_32_5_whl
+            .file_name()
+            .and_then(OsStr::to_str)
+            .unwrap();
+        let wheel_file = WheelFile::parse_file_name(file_name).unwrap();
+        assert_eq!("requests", wheel_file.raw_project_name);
+        assert_eq!("2.32.5", wheel_file.raw_version);
+
+        struct RequestsMetadataReader(ZipArchive<File>);
+        impl<'a> MetadataReader<'a> for RequestsMetadataReader {
+            fn read(&mut self, _: &str, path_components: &[&str]) -> anyhow::Result<String> {
+                Ok(io::read_to_string(
+                    self.0.by_name(&path_components.join("/"))?,
+                )?)
+            }
+        }
+        let mut metadata_reader = RequestsMetadataReader(
+            ZipArchive::new(File::open(requests_2_32_5_whl).unwrap()).unwrap(),
+        );
+
+        let wheel = WheelMetadata::parse(wheel_file, &mut metadata_reader).unwrap();
+        assert_eq!(
+            PackageName::new("requests".into()).unwrap(),
+            wheel.project_name
+        );
+        assert_eq!(Version::new([2, 32, 5]), wheel.version);
+        assert_eq!(
+            Some(VersionSpecifiers::from_str(">=3.9").unwrap()),
+            wheel.requires_python
+        );
+        assert_eq!(
+            vec![
+                Requirement::from_str("charset_normalizer<4,>=2").unwrap(),
+                Requirement::from_str("idna<4,>=2.5").unwrap(),
+                Requirement::from_str("urllib3<3,>=1.21.1").unwrap(),
+                Requirement::from_str("certifi>=2017.4.17").unwrap(),
+                Requirement::from_str("PySocks!=1.5.7,>=1.5.6; extra == \"socks\"").unwrap(),
+                Requirement::from_str("chardet<6,>=3.0.2; extra == \"use-chardet-on-py3\"")
+                    .unwrap(),
+            ],
+            wheel.requires_dists
+        );
+    }
+}

--- a/crates/pex/src/wheel/mod.rs
+++ b/crates/pex/src/wheel/mod.rs
@@ -1,0 +1,9 @@
+// Copyright 2026 Pex project contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+mod file;
+mod metadata;
+
+pub(crate) use file::WheelFile;
+pub(crate) use metadata::MetadataReader;
+pub use metadata::WheelMetadata;

--- a/crates/pex/src/wheel/mod.rs
+++ b/crates/pex/src/wheel/mod.rs
@@ -1,9 +1,13 @@
 // Copyright 2026 Pex project contributors.
 // SPDX-License-Identifier: Apache-2.0
 
+mod entry_points;
 mod file;
 mod metadata;
+mod package;
 
+pub use entry_points::{EntryPoint, EntryPoints};
 pub(crate) use file::WheelFile;
 pub(crate) use metadata::MetadataReader;
 pub use metadata::WheelMetadata;
+pub use package::repackage_wheels;

--- a/crates/pex/src/wheel/package.rs
+++ b/crates/pex/src/wheel/package.rs
@@ -154,6 +154,7 @@ fn extract_index(
     let dest_path = dest_dir.join(rel_path);
     #[cfg(windows)]
     let dest_path = {
+        use std::borrow::Cow;
         let mut dest_path = Cow::Borrowed(dest_dir);
         for component in rel_path.split("/") {
             dest_path = Cow::Owned(dest_path.join(component))

--- a/crates/pex/src/wheel/package.rs
+++ b/crates/pex/src/wheel/package.rs
@@ -1,0 +1,494 @@
+// Copyright 2026 Pex project contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::{HashMap, HashSet};
+use std::ffi::OsStr;
+use std::io;
+use std::io::{Read, Seek};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::anyhow;
+use csv::{Terminator, Trim};
+use fs_err as fs;
+use fs_err::File;
+use logging_timer::time;
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use serde::Deserialize;
+use serde::de::DeserializeOwned;
+use zip::read::ZipArchiveMetadata;
+use zip::write::{FileOptions, SimpleFileOptions};
+use zip::{CompressionMethod, ZipArchive, ZipWriter};
+
+use crate::wheel::WheelFile;
+use crate::{EntryPoints, Layout, Pex};
+
+#[time("debug", "{}")]
+pub fn repackage_wheels(
+    pex: &Pex,
+    compression_method: CompressionMethod,
+    compression_level: Option<i64>,
+    dest_dir: &Path,
+) -> anyhow::Result<Vec<File>> {
+    let wheel_files = pex
+        .info
+        .parse_distributions()
+        .collect::<Result<Vec<_>, _>>()?;
+    match pex.layout {
+        Layout::Loose | Layout::Packed => {
+            let is_whl_zip = pex.info.deps_are_wheel_files || pex.layout == Layout::Packed;
+            wheel_files
+                .into_par_iter()
+                .map(|wheel_file: WheelFile| {
+                    repackage_directory_pex_wheel(
+                        pex.path,
+                        &wheel_file,
+                        is_whl_zip,
+                        compression_method,
+                        compression_level,
+                        dest_dir,
+                    )
+                })
+                .collect::<anyhow::Result<Vec<_>>>()
+        }
+        Layout::ZipApp => {
+            let pex_zip = ZipArchive::new(File::open(pex.path)?)?;
+            let zip_metadata = pex_zip.metadata();
+            wheel_files
+                .into_par_iter()
+                .map(|wheel_file: WheelFile| {
+                    repackage_zipapp_pex_wheel(
+                        pex.path,
+                        zip_metadata.clone(),
+                        &wheel_file,
+                        pex.info.deps_are_wheel_files,
+                        compression_method,
+                        compression_level,
+                        dest_dir,
+                    )
+                })
+                .collect::<anyhow::Result<Vec<_>>>()
+        }
+    }
+}
+
+fn repackage_zipapp_pex_wheel(
+    pex_zip: &Path,
+    zip_metadata: Arc<ZipArchiveMetadata>,
+    wheel_file: &WheelFile,
+    is_whl_zip: bool,
+    compression_method: CompressionMethod,
+    compression_level: Option<i64>,
+    dest_dir: &Path,
+) -> anyhow::Result<File> {
+    let mut pex_zip_fp =
+        unsafe { ZipArchive::unsafe_new_with_metadata(File::open(pex_zip)?, zip_metadata.clone()) };
+    if is_whl_zip {
+        recompress_whl(
+            pex_zip_fp.by_name_seek(&format!(
+                ".deps/{wheel_file_name}",
+                wheel_file_name = wheel_file.file_name
+            ))?,
+            wheel_file,
+            compression_method,
+            compression_level,
+            dest_dir,
+        )
+    } else {
+        let wheel_prefix = format!(
+            ".deps/{wheel_file_name}/",
+            wheel_file_name = wheel_file.file_name
+        );
+        let extract_indices = (0..pex_zip_fp.len())
+            .filter_map(|index| {
+                pex_zip_fp.by_index(index).ok().and_then(|file| {
+                    if file.name().starts_with(&wheel_prefix) {
+                        Some(index)
+                    } else {
+                        None
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+        // TODO: XXX: Implement logic to go straight from input zip to output zip.
+        fs::create_dir_all(dest_dir)?;
+        let temp_dir = tempfile::tempdir_in(dest_dir)?;
+        extract_indices.into_par_iter().try_for_each(|index| {
+            extract_index(
+                pex_zip,
+                zip_metadata.clone(),
+                index,
+                &wheel_prefix,
+                temp_dir.path(),
+            )
+        })?;
+        compress_whl(
+            temp_dir.path(),
+            wheel_file,
+            compression_method,
+            compression_level,
+            dest_dir,
+        )
+    }
+}
+
+fn extract_index(
+    pex_zip: &Path,
+    zip_metadata: Arc<ZipArchiveMetadata>,
+    index: usize,
+    strip_prefix: &str,
+    dest_dir: &Path,
+) -> anyhow::Result<()> {
+    let mut pex_zip_fp =
+        unsafe { ZipArchive::unsafe_new_with_metadata(File::open(pex_zip)?, zip_metadata) };
+    let mut entry = pex_zip_fp.by_index(index)?;
+
+    let rel_path = entry.name().strip_prefix(strip_prefix).ok_or_else(|| {
+        anyhow!(
+            "Zip entry {name} in {pex} did not have expected prefix {strip_prefix}.",
+            name = entry.name(),
+            pex = pex_zip.display()
+        )
+    })?;
+    #[cfg(unix)]
+    let dest_path = dest_dir.join(rel_path);
+    #[cfg(windows)]
+    let dest_path = {
+        let mut dest_path = Cow::Borrowed(dest_dir);
+        for component in rel_path.split("/") {
+            dest_path = Cow::Owned(dest_path.join(component))
+        }
+        dest_path.into_owned()
+    };
+
+    if entry.is_dir() {
+        fs::create_dir_all(dest_path)?;
+    } else {
+        if let Some(parent_dir) = dest_path.parent() {
+            fs::create_dir_all(parent_dir)?;
+        }
+        io::copy(&mut entry, &mut File::create_new(dest_path)?)?;
+    }
+    Ok(())
+}
+
+fn repackage_directory_pex_wheel(
+    pex_dir: &Path,
+    wheel_file: &WheelFile,
+    is_whl_zip: bool,
+    compression_method: CompressionMethod,
+    compression_level: Option<i64>,
+    dest_dir: &Path,
+) -> anyhow::Result<File> {
+    let wheel_path = pex_dir.join(".deps").join(wheel_file.file_name);
+    if is_whl_zip {
+        recompress_whl(
+            File::open(wheel_path)?,
+            wheel_file,
+            compression_method,
+            compression_level,
+            dest_dir,
+        )
+    } else {
+        compress_whl(
+            &wheel_path,
+            wheel_file,
+            compression_method,
+            compression_level,
+            dest_dir,
+        )
+    }
+}
+
+fn recompress_whl(
+    wheel: impl Read + Seek,
+    wheel_file: &WheelFile,
+    compression_method: CompressionMethod,
+    compression_level: Option<i64>,
+    dest_dir: &Path,
+) -> anyhow::Result<File> {
+    let mut whl = ZipArchive::new(wheel)?;
+    // TODO: XXX: Implement logic to go straight from input zip to output zip.
+    fs::create_dir_all(dest_dir)?;
+    let temp_dir = tempfile::tempdir_in(dest_dir)?;
+    whl.extract(temp_dir.path())?;
+    compress_whl(
+        temp_dir.path(),
+        wheel_file,
+        compression_method,
+        compression_level,
+        dest_dir,
+    )
+}
+
+fn load_from_json<D: DeserializeOwned>(path: impl AsRef<Path>) -> anyhow::Result<Option<D>> {
+    if path.as_ref().exists() {
+        return Ok(Some(serde_json::from_reader(File::open(path.as_ref())?)?));
+    }
+    Ok(None)
+}
+
+#[derive(Deserialize)]
+struct WheelLayout {
+    stash_dir: PathBuf,
+}
+
+impl WheelLayout {
+    fn load(path: impl AsRef<Path>) -> anyhow::Result<Option<Self>> {
+        load_from_json(path)
+    }
+}
+
+#[derive(Deserialize)]
+struct RecordEntry {
+    path: String,
+    _hash: String,
+    _size: usize,
+}
+
+fn has_legacy_bin_dir(wheel_dir: &Path, wheel_file: &WheelFile) -> anyhow::Result<Option<PathBuf>> {
+    let bin_dir = wheel_dir.join("bin");
+    if bin_dir.is_dir() {
+        for record in csv::ReaderBuilder::new()
+            .quote(b'"')
+            .delimiter(b',')
+            .terminator(Terminator::CRLF)
+            .trim(Trim::All)
+            .from_path(wheel_dir.join(wheel_file.dist_info_dir()).join("RECORD"))?
+            .into_deserialize()
+        {
+            let entry: RecordEntry = record?;
+            // N.B.: The spec here is very poor:
+            // https://packaging.python.org/en/latest/specifications/recording-installed-packages/#the-record-file
+            // There is no such thing as "on Windows" since a non-platform-specific wheel could be
+            // created on Windows or Unix and uploaded to a registry. That said, the occurrence of
+            // a dir name like bin/suffix\\ on Windows or vice versa seems unlikely due to all the
+            // problems it would cause the wheel author when people went to use it.
+            if &entry.path == "bin"
+                || entry.path.starts_with("bin/")
+                || entry.path.starts_with("bin\\")
+            {
+                return Ok(None);
+            }
+        }
+        Ok(Some(bin_dir))
+    } else {
+        Ok(None)
+    }
+}
+
+#[derive(Copy, Clone, Debug, Deserialize)]
+struct DateTime(u16, u8, u8, u8, u8, u8);
+
+impl TryInto<zip::DateTime> for DateTime {
+    type Error = anyhow::Error;
+
+    fn try_into(self) -> Result<zip::DateTime, Self::Error> {
+        let (year, month, day, hour, minute, second) =
+            (self.0, self.1, self.2, self.3, self.4, self.5);
+        Ok(zip::DateTime::from_date_and_time(
+            year, month, day, hour, minute, second,
+        )?)
+    }
+}
+
+#[derive(Deserialize)]
+struct OriginalWheelInfo {
+    entries: Vec<(PathBuf, DateTime, u32)>,
+}
+
+impl OriginalWheelInfo {
+    fn load(path: impl AsRef<Path>) -> anyhow::Result<Option<Self>> {
+        load_from_json(path)
+    }
+
+    fn try_into_file_options(
+        self,
+        base_options: SimpleFileOptions,
+    ) -> anyhow::Result<HashMap<PathBuf, FileOptions<'static, ()>>> {
+        self.entries
+            .into_iter()
+            .map(|(name, last_modified, external_attr)| {
+                last_modified.try_into().map(|date_time| {
+                    let options = base_options
+                        .last_modified_time(date_time)
+                        .unix_permissions(external_attr >> 16);
+                    (name, options)
+                })
+            })
+            .collect::<anyhow::Result<_>>()
+    }
+}
+
+fn load_entry_points(wheel_dir: &Path, wheel_file: &WheelFile) -> anyhow::Result<EntryPoints> {
+    let entry_points = wheel_dir
+        .join(wheel_file.dist_info_dir())
+        .join("entry_points.txt");
+    Ok(if entry_points.exists() {
+        EntryPoints::load(File::open(entry_points)?)?
+    } else {
+        EntryPoints::empty()
+    })
+}
+
+fn data_dir_relpath(
+    wheel_dir: &Path,
+    wheel_file: &WheelFile,
+    stash_dir_relpath: &Path,
+) -> anyhow::Result<(bool, PathBuf)> {
+    let mut components = stash_dir_relpath.iter();
+    let (is_scripts_dir, dir_name) = components
+        .next()
+        .map(|dir_name| {
+            if dir_name == "bin" {
+                (true, OsStr::new("scripts"))
+            } else {
+                (false, dir_name)
+            }
+        })
+        .ok_or_else(|| {
+            anyhow!(
+                "Unexpected stash dir entry for {wheel} at {dir}: {entry}",
+                wheel = wheel_file.file_name,
+                dir = wheel_dir.display(),
+                entry = stash_dir_relpath.display()
+            )
+        })?;
+    Ok((
+        is_scripts_dir,
+        PathBuf::from_iter([dir_name].into_iter().chain(components)),
+    ))
+}
+
+fn compress_whl(
+    wheel_dir: &Path,
+    wheel_file: &WheelFile,
+    compression_method: CompressionMethod,
+    compression_level: Option<i64>,
+    dest_dir: &Path,
+) -> anyhow::Result<File> {
+    fs::create_dir_all(dest_dir)?;
+    let dest_wheel = dest_dir.join(wheel_file.file_name);
+    let compressed = File::create(&dest_wheel)?;
+    let mut compressed_whl = ZipWriter::new(compressed);
+    let directory_options = SimpleFileOptions::default();
+    let file_options = SimpleFileOptions::default()
+        .compression_method(compression_method)
+        .compression_level(compression_level);
+
+    let mut excludes: HashSet<PathBuf> = HashSet::new();
+
+    let pex_info_dir = wheel_dir.join(wheel_file.pex_info_info_dir());
+    let mut original_wheel_info = if let Some(wheel_info) =
+        OriginalWheelInfo::load(pex_info_dir.join("original-whl-info.json"))?
+    {
+        wheel_info.try_into_file_options(file_options)?
+    } else {
+        HashMap::new()
+    };
+    excludes.insert(pex_info_dir);
+
+    let layout_file = wheel_dir.join(".layout.json");
+    let stash_dir = 'result: {
+        if let Some(layout) = WheelLayout::load(&layout_file)? {
+            let stash_dir = wheel_dir.join(layout.stash_dir);
+            if stash_dir.exists() {
+                break 'result Some(stash_dir);
+            }
+        }
+        None
+    };
+    if let Some(stash_dir) = stash_dir {
+        let entry_points = load_entry_points(wheel_dir, wheel_file)?;
+        let data_dir = wheel_file.data_dir();
+        let mut scripts = Vec::new();
+        for entry in walkdir::WalkDir::new(&stash_dir).min_depth(1) {
+            let entry = entry?;
+            let stash_dir_relpath = entry.path().strip_prefix(&stash_dir).expect(
+                "Walked unpacked wheel paths should be child paths of the unpacked wheel root dir.",
+            );
+            let (is_scripts_dir, relpath) =
+                data_dir_relpath(wheel_dir, wheel_file, stash_dir_relpath)?;
+            if entry.path().is_dir() {
+                if is_scripts_dir {
+                    continue;
+                }
+                compressed_whl
+                    .add_directory_from_path(data_dir.join(relpath), directory_options)?;
+            } else {
+                let data_dir_path = data_dir.join(relpath);
+                let options = original_wheel_info
+                    .remove(&data_dir_path)
+                    .unwrap_or(file_options);
+                if is_scripts_dir {
+                    match entry.file_name().to_str() {
+                        None => scripts.push((File::open(entry.path())?, data_dir_path, options)),
+                        Some(script_name) if !entry_points.is_script(script_name) => {
+                            scripts.push((File::open(entry.path())?, data_dir_path, options));
+                        }
+                        _ => {}
+                    }
+                } else {
+                    compressed_whl.start_file_from_path(data_dir_path, options)?;
+                    io::copy(&mut File::open(entry.path())?, &mut compressed_whl)?;
+                }
+            }
+        }
+        if !scripts.is_empty() {
+            compressed_whl.add_directory_from_path(data_dir.join("scripts"), directory_options)?;
+            for (mut script_file, data_dir_path, options) in scripts {
+                compressed_whl.start_file_from_path(data_dir_path, options)?;
+                io::copy(&mut script_file, &mut compressed_whl)?;
+            }
+        }
+        excludes.insert(stash_dir);
+    } else if let Some(bin_dir) = has_legacy_bin_dir(wheel_dir, wheel_file)? {
+        let entry_points = load_entry_points(wheel_dir, wheel_file)?;
+        let dst_dir = wheel_file.data_dir().join("scripts");
+        for entry in walkdir::WalkDir::new(&bin_dir).min_depth(1) {
+            let entry = entry?;
+            if let Some(name) = entry.file_name().to_str()
+                && entry_points.is_script(name)
+            {
+                continue;
+            }
+            let dst_rel_path = dst_dir.join(entry.path().strip_prefix(&bin_dir).expect(
+                "Walked unpacked wheel paths should be child paths of the unpacked wheel root dir.",
+            ));
+            if entry.path().is_dir() {
+                compressed_whl.add_directory_from_path(dst_rel_path, directory_options)?;
+            } else {
+                let options = original_wheel_info
+                    .remove(&dst_rel_path)
+                    .unwrap_or(file_options);
+                compressed_whl.start_file_from_path(dst_rel_path, options)?;
+                io::copy(&mut File::open(entry.path())?, &mut compressed_whl)?;
+            }
+        }
+        excludes.insert(bin_dir);
+    }
+    excludes.insert(layout_file);
+
+    for entry in walkdir::WalkDir::new(wheel_dir)
+        .min_depth(1)
+        .into_iter()
+        .filter_entry(|entry| !excludes.contains(entry.path()))
+    {
+        let entry = entry?;
+        let dst_rel_path = entry.path().strip_prefix(wheel_dir).expect(
+            "Walked unpacked wheel paths should be child paths of the unpacked wheel root dir.",
+        );
+        if entry.path().is_dir() {
+            compressed_whl.add_directory_from_path(dst_rel_path, directory_options)?;
+        } else {
+            let options = original_wheel_info
+                .remove(dst_rel_path)
+                .unwrap_or(file_options);
+            compressed_whl.start_file_from_path(dst_rel_path, options)?;
+            io::copy(&mut File::open(entry.path())?, &mut compressed_whl)?;
+        }
+    }
+
+    compressed_whl.finish()?;
+    Ok(File::open(dest_wheel)?)
+}

--- a/crates/venv/src/venv_pex.rs
+++ b/crates/venv/src/venv_pex.rs
@@ -13,10 +13,9 @@ use cache::{Fingerprint, default_digest, fingerprint_file};
 use fs_err as fs;
 use fs_err::File;
 use indexmap::IndexMap;
-use ini::{Ini, Properties};
 use log::warn;
 use logging_timer::time;
-use pex::{BinPath, Layout, Pex, PexInfo, ResolvedWheel};
+use pex::{BinPath, EntryPoint, EntryPoints, Layout, Pex, PexInfo, ResolvedWheel};
 use platform::{mark_executable, path_as_bytes, path_as_str, symlink_or_link_or_copy};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use scripts::{Scripts, VenvPex, VenvPexRepl};
@@ -122,45 +121,48 @@ fn install_scripts(
     shebang_arg: Option<&str>,
     provenance: Arc<Provenance>,
 ) -> anyhow::Result<()> {
-    let entry_points = Ini::load_from_file(entry_points_txt)?;
-    if let Some(console_scripts) = entry_points.section(Some("console_scripts"))
-        && !console_scripts.is_empty()
-    {
-        let script_dir = virtualenv.prefix().join(virtualenv.bin_dir_relpath);
-        for (name, entry_point) in console_scripts {
-            let script_path = script_dir
-                .join(name)
-                .with_extension(env::consts::EXE_EXTENSION);
-            let script_contents =
-                create_script_contents(shebang_interpreter, shebang_arg, entry_point)?;
-            let script_file = match File::create_new(&script_path) {
-                Ok(script_file) => {
-                    provenance.record(entry_point, script_path);
-                    script_file
-                }
-                Err(err) if err.kind() == ErrorKind::AlreadyExists => {
-                    let fingerprint =
-                        Fingerprint::try_from(BufReader::new(script_contents.as_bytes()))?;
-                    provenance.record_collision(
-                        entry_point,
-                        fingerprint,
-                        script_contents.len(),
-                        script_path,
-                    );
-                    return Ok(());
-                }
-                Err(err) => bail!("{err}"),
-            };
-            write_script(pex, shebang_interpreter, script_file, script_contents)?;
-        }
+    let entry_points = EntryPoints::load(File::open(entry_points_txt)?)?;
+    if entry_points.is_empty() {
+        return Ok(());
     }
-    if let Some(gui_scripts) = entry_points.section(Some("gui_scripts"))
-        && !gui_scripts.is_empty()
-    {
-        struct GuiScriptsList<'a>(&'a Properties);
+
+    let script_dir = virtualenv.prefix().join(virtualenv.bin_dir_relpath);
+    for (name, entry_point) in entry_points.console_scripts() {
+        let script_path = script_dir
+            .join(name)
+            .with_extension(env::consts::EXE_EXTENSION);
+        let script_contents =
+            create_script_contents(shebang_interpreter, shebang_arg, entry_point)?;
+        let script_file = match File::create_new(&script_path) {
+            Ok(script_file) => {
+                provenance.record(entry_point, script_path);
+                script_file
+            }
+            Err(err) if err.kind() == ErrorKind::AlreadyExists => {
+                let fingerprint =
+                    Fingerprint::try_from(BufReader::new(script_contents.as_bytes()))?;
+                provenance.record_collision(
+                    entry_point,
+                    fingerprint,
+                    script_contents.len(),
+                    script_path,
+                );
+                return Ok(());
+            }
+            Err(err) => bail!("{err}"),
+        };
+        write_script(pex, shebang_interpreter, script_file, script_contents)?;
+    }
+
+    let gui_scripts = entry_points
+        .gui_scripts()
+        .map(|(name, _)| name)
+        .collect::<Vec<_>>();
+    if !gui_scripts.is_empty() {
+        struct GuiScriptsList<'a>(Vec<&'a str>);
         impl<'a> Display for GuiScriptsList<'a> {
             fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-                for (name, _) in self.0 {
+                for name in &self.0 {
                     writeln!(f, "{name}")?;
                 }
                 Ok(())
@@ -210,7 +212,7 @@ fn write_script(
 fn create_script_contents(
     shebang_interpreter: &Path,
     shebang_arg: Option<&str>,
-    entry_point: &str,
+    entry_point: &EntryPoint,
 ) -> anyhow::Result<String> {
     struct RenderShebang<'a>(&'a str, Option<&'a str>);
     impl<'a> Display for RenderShebang<'a> {
@@ -224,27 +226,25 @@ fn create_script_contents(
     }
     let shebang = RenderShebang(path_as_str(shebang_interpreter)?, shebang_arg);
 
-    let mut components = entry_point.splitn(2, ":");
-    let modname = components
-        .next()
-        .expect("A split always yield at least one item.");
-    if let Some(attrs) = components.next()
-        && !attrs.is_empty()
-    {
-        struct RenderAttrsTuple<'a>(Vec<&'a str>);
-        impl<'a> Display for RenderAttrsTuple<'a> {
-            fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-                write!(f, "(")?;
-                for attr in &self.0 {
-                    write!(f, "\"{attr}\",")?;
+    match entry_point {
+        EntryPoint::Callable {
+            module: modname,
+            attribute_chain: attrs,
+        } => {
+            struct RenderAttrsTuple<'a>(Vec<&'a str>);
+            impl<'a> Display for RenderAttrsTuple<'a> {
+                fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+                    write!(f, "(")?;
+                    for attr in &self.0 {
+                        write!(f, "\"{attr}\",")?;
+                    }
+                    write!(f, ")")?;
+                    Ok(())
                 }
-                write!(f, ")")?;
-                Ok(())
             }
-        }
 
-        Ok(format!(
-            r##"{shebang}
+            Ok(format!(
+                r##"{shebang}
 # -*- coding: utf-8 -*-
 import importlib
 import sys
@@ -256,10 +256,10 @@ for attr in {attrs_tuple}:
 if __name__ == "__main__":
     sys.exit(entry_point())
 "##,
-            attrs_tuple = RenderAttrsTuple(attrs.split(".").collect())
-        ))
-    } else {
-        Ok(format!(
+                attrs_tuple = RenderAttrsTuple(attrs.split(".").collect())
+            ))
+        }
+        EntryPoint::Module(modname) => Ok(format!(
             r##"{shebang}
 # -*- coding: utf-8 -*-
 import runpy
@@ -269,7 +269,7 @@ if __name__ == "__main__":
     runpy.run_module("{modname}", run_name="__main__", alter_sys=True)
     sys.exit(0)
 "##,
-        ))
+        )),
     }
 }
 

--- a/pexrc.rs
+++ b/pexrc.rs
@@ -6,8 +6,9 @@
 use std::collections::HashSet;
 use std::path::PathBuf;
 
-use clap::{ArgAction, Parser, Subcommand};
-use pexrc::commands::{info, inject, script};
+use clap::{ArgAction, Parser, Subcommand, ValueEnum};
+use pex::Pex;
+use pexrc::commands::{extract, info, inject, script};
 use pexrc::embeds::{CLIB_BY_TARGET, PROXY_BY_TARGET};
 use target::Target;
 
@@ -25,10 +26,44 @@ struct Cli {
     command: Commands,
 }
 
+#[derive(Clone, ValueEnum)]
+enum CompressionMethod {
+    Deflated,
+    Zstd,
+}
+
+impl From<CompressionMethod> for zip::CompressionMethod {
+    fn from(val: CompressionMethod) -> Self {
+        match val {
+            CompressionMethod::Deflated => zip::CompressionMethod::Deflated,
+            CompressionMethod::Zstd => zip::CompressionMethod::Zstd,
+        }
+    }
+}
+
 #[derive(Subcommand)]
 enum Commands {
+    /// Extract Pex dependencies as zstd wheels.
+    Extract {
+        #[arg(short = 'Z', long, value_enum, default_value_t = CompressionMethod::Zstd)]
+        compression_method: CompressionMethod,
+
+        #[arg(long)]
+        compression_level: Option<i64>,
+
+        /// The directory to extract the wheels to.
+        #[arg(short = 'd', long)]
+        dest_dir: PathBuf,
+
+        /// The Pex to extract dependency wheels from.
+        #[arg(value_name = "FILE")]
+        pex: PathBuf,
+    },
     /// Inject a traditional PEX with the pexrc runtime.
     Inject {
+        #[arg(short = 'Z', long, value_enum, default_value_t = CompressionMethod::Zstd)]
+        compression_method: CompressionMethod,
+
         #[arg(long)]
         compression_level: Option<i64>,
 
@@ -65,10 +100,22 @@ fn main() -> anyhow::Result<()> {
     cli.color.write_global();
 
     match cli.command {
+        Commands::Extract {
+            compression_method,
+            compression_level,
+            dest_dir,
+            pex,
+        } => extract::to_dir(
+            &dest_dir,
+            Pex::load(&pex)?,
+            compression_method.into(),
+            compression_level,
+        ),
         Commands::Inject {
-            pexes,
+            compression_method,
             compression_level,
             targets,
+            pexes,
         } => {
             let (clibs, proxies) = if !targets.is_empty() {
                 (
@@ -98,7 +145,13 @@ fn main() -> anyhow::Result<()> {
             } else {
                 (None, None)
             };
-            inject::inject_all(pexes, compression_level, clibs.as_ref(), proxies.as_ref())
+            inject::inject_all(
+                pexes,
+                compression_method.into(),
+                compression_level,
+                clibs.as_ref(),
+                proxies.as_ref(),
+            )
         }
         Commands::Info => info::display(),
         Commands::Script {

--- a/src/commands/extract.rs
+++ b/src/commands/extract.rs
@@ -1,0 +1,50 @@
+// Copyright 2026 Pex project contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::cmp;
+use std::io::BufReader;
+use std::path::Path;
+
+use cache::Fingerprint;
+use owo_colors::OwoColorize;
+use pex::Pex;
+use zip::CompressionMethod;
+
+pub fn to_dir(
+    dest_dir: &Path,
+    pex: Pex,
+    compression_method: CompressionMethod,
+    compression_level: Option<i64>,
+) -> anyhow::Result<()> {
+    let wheels = pex::repackage_wheels(&pex, compression_method, compression_level, dest_dir)?;
+    let count = wheels.len();
+
+    let mut wheel_info = Vec::with_capacity(count);
+    let mut max_width = 0;
+    for wheel in wheels {
+        let path = wheel.path().display().to_string();
+        max_width = cmp::max(max_width, path.len());
+        wheel_info.push((
+            path,
+            wheel.metadata()?,
+            Fingerprint::try_from(BufReader::new(wheel))?,
+        ));
+    }
+
+    anstream::println!(
+        "Extracted {count} {wheels}:",
+        count = count.yellow(),
+        wheels = if count == 1 { "wheel" } else { "wheels" }
+    );
+    for (idx, (path, metadata, fingerprint)) in wheel_info.into_iter().enumerate() {
+        anstream::println!(
+            "{idx:>3}. {path} {pad}{size:<8} bytes {alg}:{fingerprint}",
+            idx = (idx + 1).yellow(),
+            pad = " ".repeat(max_width - path.len()),
+            size = metadata.len().yellow(),
+            alg = "sha256-base64".green(),
+            fingerprint = fingerprint.base64_digest().green(),
+        )
+    }
+    Ok(())
+}

--- a/src/commands/inject.rs
+++ b/src/commands/inject.rs
@@ -23,18 +23,20 @@ use crate::embeds::{CLIBS_DIR, PROXIES_DIR};
 
 pub fn inject_all(
     pexes: Vec<PathBuf>,
+    compression_method: CompressionMethod,
     compression_level: Option<i64>,
     clibs: Option<&HashSet<&Path>>,
     proxies: Option<&HashSet<&Path>>,
 ) -> anyhow::Result<()> {
     for pex in pexes {
-        inject(&pex, compression_level, clibs, proxies)?
+        inject(&pex, compression_method, compression_level, clibs, proxies)?
     }
     Ok(())
 }
 
 fn inject(
     pex: &Path,
+    compression_method: CompressionMethod,
     compression_level: Option<i64>,
     clibs: Option<&HashSet<&Path>>,
     proxies: Option<&HashSet<&Path>>,
@@ -42,7 +44,13 @@ fn inject(
     let pex = Pex::load(pex)?;
     match pex.layout {
         Layout::Loose | Layout::Packed => inject_pex_dir(pex.path, clibs, proxies),
-        Layout::ZipApp => inject_pex_zip(pex.path, compression_level, clibs, proxies),
+        Layout::ZipApp => inject_pex_zip(
+            pex.path,
+            compression_method,
+            compression_level,
+            clibs,
+            proxies,
+        ),
     }
 }
 
@@ -162,6 +170,7 @@ fn embed_in_dir(
 
 fn inject_pex_zip(
     pex: &Path,
+    compression_method: CompressionMethod,
     compression_level: Option<i64>,
     clibs: Option<&HashSet<&Path>>,
     proxies: Option<&HashSet<&Path>>,
@@ -200,7 +209,7 @@ fn inject_pex_zip(
     let mut dst_zip = ZipWriter::new(&dst_zip_fp);
 
     let zstd_file_options = SimpleFileOptions::default()
-        .compression_method(CompressionMethod::Zstd)
+        .compression_method(compression_method)
         .compression_level(compression_level);
     let stored_file_options =
         SimpleFileOptions::default().compression_method(CompressionMethod::Stored);

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2026 Pex project contributors.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod extract;
 pub mod info;
 pub mod inject;
 pub mod script;


### PR DESCRIPTION
Since experiments showed the fasted installs were from PEXes that
contain zstd re-compressed wheels (no chroots), the aim is to have
`pexrc inject` convert from the existing 6 (
{zipapp, packed, loose} x {chroot, whl}) formats to just 2: zipapp
and packed, with dependencies embedded as zstd re-compressed wheels
in all cases.

Currently the infrastructure is faithful round-tripping everything
except entry order in the produced wheels (perms & time stamps are
preserved). A follow-up will preserve order and a final follow up will
change over `pexrc inject` to use this infra which should allow a fair
bit of runtime code variants to be eliminated. All this will enable
a very simpple implementation of the `repository extract` Pex tool as
a bonus.