### PR TITLE
The `pexrc inject` command now produces 2 formats.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1957,6 +1957,7 @@ dependencies = [
  "pexrs",
  "platform",
  "python-proxy",
+ "rayon",
  "scripts",
  "sha2 0.11.0",
  "strum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -224,6 +224,7 @@ pex = { path = "crates/pex" }
 pexrs = { path = "crates/pexrs" }
 platform = { path = "crates/platform" }
 python-proxy = { path = "crates/python-proxy" }
+rayon = { workspace = true }
 scripts = { path = "crates/scripts", features = ["embedded"] }
 sha2 = { workspace = true }
 strum = { workspace = true }

--- a/crates/cache/src/fingerprint.rs
+++ b/crates/cache/src/fingerprint.rs
@@ -53,6 +53,29 @@ impl<R: Read> TryFrom<BufReader<R>> for Fingerprint {
     }
 }
 
+pub struct DigestingReader<D: Digest, R: Read> {
+    digest: D,
+    reader: R,
+}
+
+impl<D: Digest, R: Read> DigestingReader<D, R> {
+    pub fn new(digest: D, reader: R) -> Self {
+        Self { digest, reader }
+    }
+
+    pub fn into_fingerprint(self) -> Fingerprint {
+        Fingerprint::new(self.digest)
+    }
+}
+
+impl<D: Digest, R: Read> Read for DigestingReader<D, R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let amount = self.reader.read(buf)?;
+        self.digest.update(&buf[0..amount]);
+        Ok(amount)
+    }
+}
+
 #[derive(Default)]
 pub struct HashOptions {
     path: bool,

--- a/crates/cache/src/lib.rs
+++ b/crates/cache/src/lib.rs
@@ -14,7 +14,14 @@ use std::sync::LazyLock;
 
 use anyhow::anyhow;
 pub use atomic::{atomic_dir, atomic_file};
-pub use fingerprint::{Fingerprint, HashOptions, default_digest, fingerprint_file, hash_file};
+pub use fingerprint::{
+    DigestingReader,
+    Fingerprint,
+    HashOptions,
+    default_digest,
+    fingerprint_file,
+    hash_file,
+};
 pub use key::Key;
 use logging_timer::time;
 

--- a/crates/pex/src/pex_info.rs
+++ b/crates/pex/src/pex_info.rs
@@ -3,7 +3,7 @@
 
 use std::borrow::Cow;
 use std::io;
-use std::io::Read;
+use std::io::{Read, Write};
 use std::path::PathBuf;
 
 use anyhow::anyhow;
@@ -112,5 +112,9 @@ impl PexInfo {
             .keys()
             .map(String::as_str)
             .map(WheelFile::parse_file_name)
+    }
+
+    pub fn write(&self, writer: impl Write) -> anyhow::Result<()> {
+        Ok(serde_json::to_writer(writer, &self)?)
     }
 }

--- a/src/commands/inject.rs
+++ b/src/commands/inject.rs
@@ -1,19 +1,22 @@
 // Copyright 2026 Pex project contributors.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::io;
-use std::io::{BufRead, Read, Seek, Write};
+use std::io::{BufRead, BufReader, Read, Seek, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, anyhow};
 use boot::{inject_boot, sh_boot_shebang, write_boot};
+use cache::{DigestingReader, Fingerprint, default_digest};
 use fs_err as fs;
 use fs_err::File;
+use indexmap::IndexMap;
 use log::info;
 use owo_colors::OwoColorize;
 use pex::{Layout, Pex};
 use platform::mark_executable;
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use scripts::Scripts;
 use tempfile::NamedTempFile;
 use zip::write::SimpleFileOptions;
@@ -43,28 +46,28 @@ fn inject(
 ) -> anyhow::Result<()> {
     let pex = Pex::load(pex)?;
     match pex.layout {
-        Layout::Loose | Layout::Packed => inject_pex_dir(pex.path, clibs, proxies),
-        Layout::ZipApp => inject_pex_zip(
-            pex.path,
-            compression_method,
-            compression_level,
-            clibs,
-            proxies,
-        ),
+        Layout::Loose | Layout::Packed => {
+            inject_pex_dir(pex, compression_method, compression_level, clibs, proxies)
+        }
+        Layout::ZipApp => {
+            inject_pex_zip(pex, compression_method, compression_level, clibs, proxies)
+        }
     }
 }
 
 fn inject_pex_dir(
-    pex: &Path,
+    mut pex: Pex,
+    compression_method: CompressionMethod,
+    compression_level: Option<i64>,
     clibs: Option<&HashSet<&Path>>,
     proxies: Option<&HashSet<&Path>>,
 ) -> anyhow::Result<()> {
     // Make sure we have a shebang early. This partially validates the pex to inject is a valid one
     // before expending too much effort copying files below.
-    let shebang = if let Some(sh_boot_shebang) = sh_boot_shebang(pex, true)? {
+    let shebang = if let Some(sh_boot_shebang) = sh_boot_shebang(pex.path, true)? {
         sh_boot_shebang
     } else {
-        let original_main = pex.join("__main__.py");
+        let original_main = pex.path.join("__main__.py");
         io::BufReader::new(File::open(&original_main)?)
             .lines()
             .next()
@@ -76,9 +79,11 @@ fn inject_pex_dir(
             })??
     };
 
-    let mut dest_pex = tempfile::tempdir_in(pex.parent().unwrap_or_else(|| Path::new(".")))?;
+    let mut dest_pex = tempfile::tempdir_in(pex.path.parent().unwrap_or_else(|| Path::new(".")))?;
     let excludes: HashSet<PathBuf> = [
         ".bootstrap",
+        ".deps",
+        "PEX-INFO",
         "__main__.py",
         "__pex__",
         "__pycache__",
@@ -86,28 +91,43 @@ fn inject_pex_dir(
         "pex-repl",
     ]
     .into_iter()
-    .map(|rel_path| pex.join(rel_path))
+    .map(|rel_path| pex.path.join(rel_path))
     .collect();
-    for entry in walkdir::WalkDir::new(pex)
+    for entry in walkdir::WalkDir::new(pex.path)
         .min_depth(1)
         .into_iter()
         .filter_entry(|entry| !excludes.contains(entry.path()))
     {
         let entry = entry?;
-        let dst = dest_pex.path().join(entry.path().strip_prefix(pex)?);
+        let dst = dest_pex.path().join(entry.path().strip_prefix(pex.path)?);
         if entry.path().is_dir() {
             fs::create_dir_all(dst)?;
         } else {
             fs::copy(entry.path(), dst)?;
         }
     }
+    let deps_dir = dest_pex.path().join(".deps");
+    pex::repackage_wheels(&pex, compression_method, compression_level, &deps_dir)?;
+    pex.info.deps_are_wheel_files = true;
+    let wheel_file_names = pex.info.distributions.into_keys().collect::<Vec<_>>();
+    pex.info.distributions = wheel_file_names
+        .into_par_iter()
+        .map(|wheel_file_name| {
+            let fingerprint = Fingerprint::try_from(BufReader::new(File::open(
+                deps_dir.join(&wheel_file_name),
+            )?))?;
+            Ok((wheel_file_name, fingerprint.hex_digest()))
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?
+        .into_iter()
+        .collect();
 
     let mut scripts = Scripts::Embedded;
     let pex_dir = dest_pex.path().join("__pex__");
     fs::create_dir_all(&pex_dir)?;
     scripts.write(dest_pex.path())?;
 
-    let dst = pex.with_extension("pexrc");
+    let dst = pex.path.with_extension("pexrc");
     let clib_dir = pex_dir.join(".clibs");
     fs::create_dir_all(&clib_dir)?;
     info!("Embedded clibs:");
@@ -132,6 +152,9 @@ fn inject_pex_dir(
         }
         embed_in_dir(path, file.contents(), &scripts_dir, true)?;
     }
+
+    pex.info
+        .write(&mut File::create_new(dest_pex.path().join("PEX-INFO"))?)?;
 
     write_boot(dest_pex.path(), &shebang)?;
 
@@ -169,21 +192,21 @@ fn embed_in_dir(
 }
 
 fn inject_pex_zip(
-    pex: &Path,
+    mut pex: Pex,
     compression_method: CompressionMethod,
     compression_level: Option<i64>,
     clibs: Option<&HashSet<&Path>>,
     proxies: Option<&HashSet<&Path>>,
 ) -> anyhow::Result<()> {
-    let zip_read_fp = File::open(pex)?;
+    let zip_read_fp = File::open(pex.path)?;
     let mut src_zip = ZipArchive::new(&zip_read_fp)?;
-    let prefix = if let Some(sh_boot_shebang) = sh_boot_shebang(pex, false)? {
+    let prefix = if let Some(sh_boot_shebang) = sh_boot_shebang(pex.path, false)? {
         Some(sh_boot_shebang.into_bytes())
     } else {
         let first_entry = src_zip.by_index(0)?;
         let zip_start = first_entry.header_start();
         if zip_start > 0 {
-            let mut prefix_reader = File::open(pex)?.take(zip_start);
+            let mut prefix_reader = File::open(pex.path)?.take(zip_start);
             let mut prefix = Vec::with_capacity(zip_start.try_into().with_context(|| {
                 format!(
                     "The zip prefix is {zip_start} bytes which is bigger than the system pointer \
@@ -198,7 +221,7 @@ fn inject_pex_zip(
         }
     };
 
-    let mut dst_zip_fp = if let Some(parent_dir) = pex.parent() {
+    let mut dst_zip_fp = if let Some(parent_dir) = pex.path.parent() {
         NamedTempFile::new_in(parent_dir)?
     } else {
         NamedTempFile::new()?
@@ -211,44 +234,51 @@ fn inject_pex_zip(
     let zstd_file_options = SimpleFileOptions::default()
         .compression_method(compression_method)
         .compression_level(compression_level);
-    let stored_file_options =
-        SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
     let other_file_options =
         SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
     let directory_options = SimpleFileOptions::default();
-    let whl_file_indicies = map_whl_file_indicies(pex)?;
     for index in 0..src_zip.len() {
-        if let Some(entry_name) = whl_file_indicies.get(&index) {
-            let zip_file = src_zip.by_index_seek(index)?;
-            dst_zip.start_file(entry_name, stored_file_options)?;
-            let whl_zip = ZipArchive::new(zip_file)?;
-            io::copy(
-                &mut re_compress(whl_zip, directory_options, zstd_file_options)?,
-                &mut dst_zip,
-            )?;
+        let mut src_file = src_zip.by_index(index)?;
+        let entry_name = src_file.name();
+        if [".bootstrap/", ".deps/", "PEX-INFO", "__pex__/"]
+            .into_iter()
+            .any(|prefix| entry_name.starts_with(prefix))
+            || entry_name == "__main__.py"
+        {
+            continue;
+        }
+        if src_file.is_dir() {
+            dst_zip.add_directory(entry_name, directory_options)?
         } else {
-            let mut src_file = src_zip.by_index(index)?;
-            let entry_name = src_file.name();
-            if [".bootstrap/", "__pex__/"]
-                .into_iter()
-                .any(|prefix| entry_name.starts_with(prefix))
-                || entry_name == "__main__.py"
-            {
-                continue;
-            }
-            if src_file.is_dir() {
-                dst_zip.add_directory(entry_name, directory_options)?
+            let options = if entry_name == "PEX-INFO" {
+                other_file_options
             } else {
-                let options = if entry_name == "PEX-INFO" {
-                    other_file_options
-                } else {
-                    zstd_file_options
-                };
-                dst_zip.start_file(entry_name, options)?;
-                io::copy(&mut src_file, &mut dst_zip)?;
-            }
+                zstd_file_options
+            };
+            dst_zip.start_file(entry_name, options)?;
+            io::copy(&mut src_file, &mut dst_zip)?;
         }
     }
+
+    let deps_dir = tempfile::tempdir_in(pex.path.parent().unwrap_or_else(|| Path::new(".")))?;
+    let stored_file_options =
+        SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+    pex::repackage_wheels(&pex, compression_method, compression_level, deps_dir.path())?;
+    pex.info.deps_are_wheel_files = true;
+    let mut distributions = IndexMap::with_capacity(pex.info.distributions.len());
+    for wheel_file_name in pex.info.distributions.into_keys() {
+        dst_zip.start_file(format!(".deps/{wheel_file_name}"), stored_file_options)?;
+        let mut digesting_reader = DigestingReader::new(
+            default_digest(),
+            File::open(deps_dir.path().join(&wheel_file_name))?,
+        );
+        io::copy(&mut digesting_reader, &mut dst_zip)?;
+        distributions.insert(
+            wheel_file_name,
+            digesting_reader.into_fingerprint().hex_digest(),
+        );
+    }
+    pex.info.distributions = distributions;
 
     dst_zip.add_directory("__pex__", directory_options)?;
     Scripts::Embedded.inject(&mut dst_zip, zstd_file_options)?;
@@ -290,12 +320,15 @@ fn inject_pex_zip(
         )?;
     }
 
+    dst_zip.start_file("PEX-INFO", other_file_options)?;
+    pex.info.write(&mut dst_zip)?;
+
     inject_boot(&mut dst_zip, deflate_options)?;
 
     dst_zip.finish()?;
     mark_executable(dst_zip_fp.as_file_mut())?;
 
-    let dst = pex.with_extension("pexrc");
+    let dst = pex.path.with_extension("pexrc");
     if dst.is_dir() {
         fs::remove_dir_all(&dst)?;
     }
@@ -329,41 +362,4 @@ fn embed_in_zip(
     io::copy(&mut embed_reader, dst_zip)?;
     anstream::eprintln!("{}.", "done".green());
     Ok(())
-}
-
-fn map_whl_file_indicies(pex: &Path) -> anyhow::Result<HashMap<usize, String>> {
-    let zip_read_fp = File::open(pex)?;
-    let mut src_zip = ZipArchive::new(&zip_read_fp)?;
-    let mut whl_file_indicies = HashMap::new();
-    for index in 0..src_zip.len() {
-        let src_file = src_zip.by_index(index)?;
-        if src_file.is_file() && src_file.compression() == CompressionMethod::Stored {
-            whl_file_indicies.insert(index, src_file.name().to_string());
-        }
-    }
-    Ok(whl_file_indicies)
-}
-
-fn re_compress(
-    mut zip: ZipArchive<impl Read + Seek>,
-    directory_options: SimpleFileOptions,
-    file_options: SimpleFileOptions,
-) -> anyhow::Result<impl Read> {
-    let mut re_compressed = tempfile::tempfile()?;
-    {
-        let mut re_zipped = ZipWriter::new(&mut re_compressed);
-        for index in 0..zip.len() {
-            let mut entry = zip.by_index(index)?;
-            let entry_name = entry.name();
-            if entry.is_dir() {
-                re_zipped.add_directory(entry_name, directory_options)?;
-            } else {
-                re_zipped.start_file(entry_name, file_options)?;
-                io::copy(&mut entry, &mut re_zipped)?;
-            }
-        }
-        re_zipped.finish()?;
-    }
-    re_compressed.rewind()?;
-    Ok(re_compressed)
 }


### PR DESCRIPTION
The prior 6 ({zipapp, packed, loose} x {whl chroots, whls}) is now
reduced to just zipapp or packed. In either case wheels are, by default,
zstd compressed. This was an easy simplification choice since these two
configurations were the fastest in both cold and warm start cases. The
PEXrc runtime retains the ability to extract dependencies from the prior
6 formats to continue to support loading old PEXes not yet converted to
PEXrcs that are on the PEX_PATH.